### PR TITLE
Update to Bulma 0.1.1

### DIFF
--- a/addon/components/bulma-checkbox.js
+++ b/addon/components/bulma-checkbox.js
@@ -11,6 +11,12 @@ export default BulmaInput.extend({
   layout,
   classNames: ['checkbox'],
   type: 'checkbox',
+  // Bindings are not comprehensive. More complex implementations should use a native element with classes applied
+  classNameBindings: [
+    'capture',
+    'checked',
+    'list'
+  ],
 
   init() {
     this._super(...arguments);

--- a/addon/components/bulma-input.js
+++ b/addon/components/bulma-input.js
@@ -1,17 +1,13 @@
 import Ember from 'ember';
 import layout from '../templates/components/bulma-input';
 import computed, { alias } from 'ember-computed-decorators';
-import { makeString, nativeAttrs, deprecations } from '../utils';
+import { makeString, deprecations } from '../utils';
 
 const {
   Component,
   get,
   set
 } = Ember;
-
-const {
-  input
-} = nativeAttrs;
 
 export default Component.extend({
   layout,
@@ -22,7 +18,32 @@ export default Component.extend({
     'isMedium:is-medium',
     'isLarge:is-large'
   ],
-  attributeBindings: ['isDisabled:disabled','disabled'].concat(input),
+  // Bindings are not comprehensive. More complex implementations should use a native element with classes applied
+  attributeBindings: [
+    'type',
+    'value',
+    'name',
+    'accept',
+    'isDisabled:disabled','disabled',
+    'autocomplete',
+    'autofocus',
+    'dirname',
+    'list',
+    'readonly',
+    'size',
+    'required',
+    'multiple',
+    'maxlength',
+    'pattern',
+    'min',
+    'step',
+    'placeholder',
+    'onkeydown',
+    'onkeyup',
+    'onkeypress',
+    'oninput',
+    'onchange'
+  ],
 
   /**
     * Default class name binding

--- a/addon/components/bulma-radio.js
+++ b/addon/components/bulma-radio.js
@@ -11,6 +11,12 @@ export default BulmaInput.extend({
   layout,
   classNames: ['radio'],
   type: 'radio',
+  // Bindings are not comprehensive. More complex implementations should use a native element with classes applied
+  classNameBindings: [
+    'capture',
+    'checked',
+    'list'
+  ],
 
   init() {
     this._super(...arguments);

--- a/addon/components/bulma-textarea.js
+++ b/addon/components/bulma-textarea.js
@@ -12,6 +12,7 @@ export default Component.extend({
   layout,
   tagName: 'textarea',
   classNames: ['textarea'],
+  // Bindings are not comprehensive. More complex implementations should use a native element with classes applied
   attributeBindings: [
     'isDisabled: disabled',
     'autofocus',

--- a/addon/components/bulma-textarea.js
+++ b/addon/components/bulma-textarea.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
 import layout from '../templates/components/bulma-textarea';
 import computed, { read } from 'ember-computed-decorators';
-import { nativeAttrs } from './../utils';
 
 const {
   Component,
@@ -9,13 +8,25 @@ const {
   set
 } = Ember;
 
-const {
-  textarea
-} = nativeAttrs;
-
 export default Component.extend({
   layout,
   tagName: 'textarea',
   classNames: ['textarea'],
-  attributeBindings: [].concat(textarea),
+  attributeBindings: [
+    'isDisabled: disabled',
+    'autofocus',
+    'cols',
+    'disabled',
+    'form',
+    'name',
+    'placeholder',
+    'readonly',
+    'required',
+    'rows',
+    'wrap',
+    'onkeydown',
+    'onkeyup',
+    'onkeypress',
+    'oninput'
+  ]
 });

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -36,46 +36,6 @@ export const camelCase = (str) => {
   }
 };
 
-const blacklist = A(['tagName', 'removeChild']);
-
-export const nativeAttrs  = {
-  /**
-    * Iterates through the prototype properties of an html element (while considering blacklisted items)
-    *
-    * @method attrsFor
-    * @private
-    */
-  attrsFor: (htmlElement) => {
-    let a = [];
-    for (var attr in htmlElement) {
-      if (!blacklist.contains(attr)) {
-        a.push(attr);
-      }
-    };
-    return a;
-  },
-
-  /**
-    * A list of all of the attributes of a native textarea
-    *
-    * @property textarea
-    * @private
-    */
-  get textarea() {
-    return this.attrsFor(window.HTMLTextAreaElement.prototype);
-  },
-
-  /**
-    * A list of all of the attributes of a native textarea
-    *
-    * @property input
-    * @private
-    */
-  get input() {
-    return this.attrsFor(window.HTMLInputElement.prototype);
-  }
-}
-
 /**
   * Deprecation messages util
   *

--- a/blueprints/ember-bulma/index.js
+++ b/blueprints/ember-bulma/index.js
@@ -11,7 +11,7 @@ module.exports = {
  	afterInstall: function() {
     return this.addBowerPackagesToProject(
       [
-        { name: 'bulma', target: '^0.0.26' }
+        { name: 'bulma', target: '^0.1.1' }
       ]
     );
   }

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-bulma",
   "dependencies": {
-    "ember": "2.6.1",
+    "ember": "~2.8.1",
     "ember-cli-shims": "0.0.6",
     "ember-cli-test-loader": "0.2.1",
     "ember-qunit": "0.4.16",
@@ -10,7 +10,7 @@
     "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.20.0",
-    "bulma": "^0.0.26",
+    "bulma": "^0.1.1",
     "font-awesome": "~4.5.0",
     "prism": "^1.4.1",
     "highlightjs": "^9.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-bulma",
-  "version": "0.0.26-b",
+  "version": "0.1.1",
   "description": "Ember Bulma is a collection of Ember components and services for Bulma, a modern CSS framework by Jeremy Thomas",
   "directories": {
     "doc": "doc",
@@ -19,7 +19,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
-    "ember-cli": "^2.6.1",
+    "ember-cli": "2.8.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.3.0",
@@ -29,7 +29,6 @@
     "ember-cli-release": "^1.0.0-beta.2",
     "ember-cli-sass": "^5.3.1",
     "ember-cli-sri": "^1.1.0",
-    "ember-cli-template-lint": "0.4.7",
     "ember-cli-uglify": "^1.2.0",
     "ember-composable-helpers": "0.16.0",
     "ember-disable-prototype-extensions": "^1.0.0",

--- a/tests/dummy/app/templates/uicomponents/modal.hbs
+++ b/tests/dummy/app/templates/uicomponents/modal.hbs
@@ -7,7 +7,7 @@
   {{#bulma-column}}
     {{bulma-button onmousedown=(toggle 'showModal' this) label="Launch Example Modal" isPrimary=true}}
 
-    {{#bulma-modal show=showModal onclose=(toggle 'showModal' this)}}
+    {{#bulma-modal show=showModal onclose=(if showModal (toggle 'showModal' this))}}
       <div class="box">
         I am a modal.
       </div>
@@ -15,8 +15,8 @@
   {{/bulma-column}}
   {{#bulma-column isHalf=true}}
     {{#themed-syntax transparent="true" language="handlebars" }}
-&#123;&#123;! Leveraging ember-composable-helpers `toggle` (not included) &#125;&#125;  
-&#123;&#123;#bulma-modal show=showModal onclose=(toggle 'showModal' this)&#125;&#125;
+&#123;&#123;! Leveraging ember-composable-helpers `toggle` (not included) &#125;&#125;
+&#123;&#123;#bulma-modal show=showModal onclose=(if showModal (toggle 'showModal' this))&#125;&#125;
   &lt;div class="box"&gt;
     I am a modal.
   &lt;/div&gt;


### PR DESCRIPTION
- Aligns with Bulma ^0.1.1 <https://github.com/jgthms/bulma/releases/tag/0.1.1>
- Fixes #39 
- Upgrades to Ember 2.8 <http://emberjs.com/blog/2016/09/08/ember-2-8-and-2-9-beta-released.html>
- Removes template linting for now