### PR TITLE
Fallback to empty string for undefined bowerDirectory

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = {
     target.options = target.options || {};
 
     // Build all paths
-    var bulmaPath = path.join(target.bowerDirectory || '', 'bulma');
+    var bulmaPath = path.join(target.bowerDirectory || 'bower_components', 'bulma');
 
     target.options.sassOptions = target.options.sassOptions || {};
     target.options.sassOptions.includePaths = target.options.sassOptions.includePaths || [];

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = {
     target.options = target.options || {};
 
     // Build all paths
-    var bulmaPath = path.join(target.bowerDirectory, 'bulma');
+    var bulmaPath = path.join(target.bowerDirectory || '', 'bulma');
 
     target.options.sassOptions = target.options.sassOptions || {};
     target.options.sassOptions.includePaths = target.options.sassOptions.includePaths || [];


### PR DESCRIPTION
From what I can tell, nested addons don't have access to the `bowerDirectory` property defined by Ember CLI. 

Rather than get an error for passing `undefined` to `Path.join`, this attempts to continue without `target.bowerDirectory`.