### PR TITLE
Fix: `Error: Cannot find module 'babel-eslint'`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,13 +1,13 @@
 module.exports = {
   root: true,
-  parser: "babel-eslint",
+  parser: 'babel-eslint',
   parserOptions: {
     ecmaVersion: 7,
     sourceType: 'module'
   },
   extends: 'eslint:recommended',
   env: {
-    'browser': true
+    browser: true
   },
   rules: {
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "author": "Open Tux",
   "license": "MIT",
   "devDependencies": {
-    "babel-eslint": "^7.1.1",
     "broccoli-asset-rev": "^2.4.5",
     "ember-cli": "2.10.0",
     "ember-cli-app-version": "^2.0.0",
@@ -56,6 +55,7 @@
     "composable"
   ],
   "dependencies": {
+    "babel-eslint": "^7.1.1",
     "broccoli-funnel": "^1.0.1",
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.10",

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
   env: {
-    'embertest': true
+    embertest: true
   }
 };


### PR DESCRIPTION
 - Moving `babel-eslint` to NPM `dependencies`

/cc @crodriguez1a 