### PR TITLE
removes bulma from bower -> npm

### DIFF
--- a/blueprints/ember-bulma/index.js
+++ b/blueprints/ember-bulma/index.js
@@ -8,31 +8,15 @@ module.exports = {
     // to us
   },
 
-  // locals: function(options) {
-  //   // Return custom template variables here.
-  //   return {
-  //     foo: options.entity.options.foo
-  //   };
-  // },
-
   afterInstall: function() {
     // NOTE: Currently adding `eslint-plugin-ember-suave` to the consuming app/addon to bypass the following error. This shouldn't be a necessary step:
     // Error: Failed to load plugin ember-suave: Cannot find module 'eslint-plugin-ember-suave'
     return this.addPackagesToProject(
       [
+        { name: 'bulma', target: '0.1.2' },
         { name: 'ember-cli-sass', target: '~6.1.2' },
         { name: 'eslint-plugin-ember-suave', target: '~1.0.0' }
       ]
-    ).then(() => {
-      return this.addBowerPackagesToProject(
-        [
-          { name: 'bulma', target: '0.1.2' }
-        ]
-      );
-    });
-  },
-
-  isDevelopingAddon: function() {
-    return false;
+    );
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "ember-bulma",
   "dependencies": {
-    "bulma": "0.1.2",
     "font-awesome": "~4.5.0",
     "prism": "^1.4.1",
     "highlightjs": "^9.4.0",

--- a/index.js
+++ b/index.js
@@ -34,8 +34,8 @@ module.exports = {
     // see: http://ember-cli.com/extending/#broccoli-build-options-for-in-repo-addons
     target.options = target.options || {};
 
-    // Build all paths
-    var bulmaPath = path.join(target.bowerDirectory || 'bower_components', 'bulma');
+    // Build path to Bulma's sass paths
+    var bulmaPath = path.join(target.project.root, 'node_modules', 'bulma');
 
     target.options.sassOptions = target.options.sassOptions || {};
     target.options.sassOptions.includePaths = target.options.sassOptions.includePaths || [];
@@ -46,8 +46,6 @@ module.exports = {
 
     var config = target.project.config(target.env) || {};
     var addonConfig = config[this.name] || {};
-
-    // console.log('addon config: ', addonConfig);
 
     this.whitelist = this.generateWhitelist(addonConfig);
     this.blacklist = this.generateBlacklist(addonConfig);
@@ -83,7 +81,7 @@ module.exports = {
         });
       }]
     });
-    // console.log('funnelTree', funnelTree);
+
     return funnelTree;
   },
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
+    "bulma": "^0.1.2",
     "ember-ajax": "^2.4.1",
     "ember-cli": "2.12.1",
     "ember-cli-content-security-policy": "^0.6.0",
@@ -40,7 +41,7 @@
     "ember-cli-htmlbars-inline-precompile": "^0.3.6",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^3.1.0",
-    "ember-cli-sass": "^6.1.2",
+    "ember-cli-sass": "^6.1.3",
     "ember-cli-shims": "^1.0.2",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",


### PR DESCRIPTION
Removes the Bulma bower dependency, and instead uses the [Bulma npm package](https://www.npmjs.com/package/bulma).

+ some other misc. cleanup

Closes #57 

