### PR TITLE
adds tests for bulma-radio 

### DIFF
--- a/addon/components/bulma-radio.js
+++ b/addon/components/bulma-radio.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import BulmaInput from '../components/bulma-input';
-import layout from '../templates/components/bulma-checkbox';
+import layout from '../templates/components/bulma-radio';
 
 const {
   get,

--- a/addon/components/bulma-radio.js
+++ b/addon/components/bulma-radio.js
@@ -21,7 +21,7 @@ export default BulmaInput.extend({
   init() {
     this._super(...arguments);
 
-    let defaultAttrBindings = get(this, 'attributeBindings').slice(0);
+    let defaultAttrBindings = get(this, 'attributeBindings').slice();
 
     defaultAttrBindings.push('checked');
 

--- a/addon/components/bulma-radio.js
+++ b/addon/components/bulma-radio.js
@@ -12,15 +12,20 @@ export default BulmaInput.extend({
 
   classNames: ['radio'],
   type: 'radio',
+
   // Bindings are not comprehensive. More complex implementations should use a native element with classes applied
   classNameBindings: [
-    'capture',
-    'checked',
-    'list'
+    'checked'
   ],
 
   init() {
     this._super(...arguments);
+
+    let defaultAttrBindings = get(this, 'attributeBindings').slice(0);
+
+    defaultAttrBindings.push('checked');
+
+    set(this, 'attributeBindings', defaultAttrBindings);
 
     // classNames reset
     // Remove the inherited `input` class name (as it breaks the styling)

--- a/addon/templates/components/bulma-radio.hbs
+++ b/addon/templates/components/bulma-radio.hbs
@@ -1,3 +1,1 @@
-{{#if hasBlock}}
-  {{yield}}
-{{/if}}
+{{yield}}

--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
+    "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-native-dom-helpers": "^0.5.2",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.14.1",
     "ember-themed-syntax": "^0.1.1",

--- a/tests/integration/components/bulma-radio-test.js
+++ b/tests/integration/components/bulma-radio-test.js
@@ -1,14 +1,39 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { find, click } from 'ember-native-dom-helpers';
+
+const sampleRadioButtons = hbs`
+  {{bulma-radio name="test" value="cool" id="test-cool"}}
+
+  {{bulma-radio name="test" value="awesome" id="test-awesome"}}
+`;
 
 moduleForComponent('bulma-radio', 'Integration | Component | bulma radio', {
   integration: true
 });
 
-test('it renders', function(assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
-  this.render(hbs`{{bulma-radio}}`);
+test('it selects an option', async function(assert) {
+  this.render(sampleRadioButtons);
 
-  assert.equal(this.$().text().trim(), '');
+  await click('#test-cool');
+
+  assert.ok(find('#test-cool').checked);
+  assert.notOk(find('#test-awesome').checked);
+
+  await click('#test-awesome');
+
+  assert.ok(find('#test-awesome').checked);
+  assert.notOk(find('#test-cool').checked);
+});
+
+test('it renders default selected option', function(assert) {
+  this.set('isChecked', true);
+
+  this.render(hbs`
+    {{bulma-radio name="test" value="cool" id="test-cool" checked=isChecked}}
+
+    {{bulma-radio name="test" value="awesome" id="test-awesome"}}
+  `);
+
+  assert.ok(find('#test-cool').checked);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1705,9 +1705,9 @@ chalk@^0.5.1:
     strip-ansi "^0.3.0"
     supports-color "^0.2.0"
 
-chalk@^2.0.0, chalk@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
+chalk@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.0.1.tgz#dbec49436d2ae15f536114e76d14656cdbc0f44d"
   dependencies:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
@@ -2351,11 +2351,12 @@ ember-cli-babel@^5.1.6:
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
 
-ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.1.0, ember-cli-babel@^6.3.0:
-  version "6.7.2"
-  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.7.2.tgz#9c0886194266f17a98fe5c536d170878ac287009"
+ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.1.0, ember-cli-babel@^6.3.0:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.7.1.tgz#98de75cb3eaf3198a80aac36ae82d8ea48c9d91f"
   dependencies:
     amd-name-resolver "0.0.7"
+    amd-name-resolver "0.0.6"
     babel-plugin-debug-macros "^0.1.11"
     babel-plugin-ember-modules-api-polyfill "^1.4.1"
     babel-plugin-transform-es2015-modules-amd "^6.24.0"
@@ -2707,6 +2708,22 @@ ember-macro-helpers@^0.15.1:
     ember-cli-string-utils "^1.1.0"
     ember-cli-test-info "^1.0.0"
     ember-weakmap "^2.0.0"
+
+ember-maybe-import-regenerator@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/ember-maybe-import-regenerator/-/ember-maybe-import-regenerator-0.1.6.tgz#35d41828afa6d6a59bc0da3ce47f34c573d776ca"
+  dependencies:
+    broccoli-funnel "^1.0.1"
+    broccoli-merge-trees "^1.0.0"
+    ember-cli-babel "^6.0.0-beta.4"
+    regenerator-runtime "^0.9.5"
+
+ember-native-dom-helpers@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.5.2.tgz#ba6123230fc32c3350f90a8f9183584a022215fa"
+  dependencies:
+    broccoli-funnel "^1.1.0"
+    ember-cli-babel "^6.1.0"
 
 ember-qunit@^2.1.3:
   version "2.2.0"
@@ -5587,6 +5604,10 @@ regenerate@^1.2.1:
 regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
+
+regenerator-runtime@^0.9.5:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz#d33eb95d0d2001a4be39659707c51b0cb71ce029"
 
 regenerator-transform@0.9.11:
   version "0.9.11"


### PR DESCRIPTION
Also, adds the missing `checked ` attr binding to `bulma-radio` component, which fixes a bug preventing a radio button from being checked.

@crodriguez1a I [removed a few `classNameBindings`](https://github.com/open-tux/ember-bulma/pull/79/files#diff-7f2d62b2c30bffd1488e957c4709b56fL17) that I did not see any styles for in bulma. I wasn't sure exactly why these were added, it looks like these were meant to be `attributeBindings`.