### PR TITLE
chore: add decorators transform for addon consumers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   # so that your addon works for all apps
   - "4"
 
-sudo: false
+sudo: required
 dist: trusty
 
 addons:

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@ember-decorators/babel-transforms": "^2.0.0",
-    "babel-eslint": "^7.2.3",
+    "babel-eslint": "^8.1.1",
     "broccoli-funnel": "^1.2.0",
     "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     }
   },
   "dependencies": {
+    "@ember-decorators/babel-transforms": "^2.0.0",
     "babel-eslint": "^7.2.3",
     "broccoli-funnel": "^1.2.0",
     "ember-cli-babel": "^6.6.0",


### PR DESCRIPTION
Per the warning ember-decorators throws (text below), the babel-transform addon needs to be installed in order to use ember-decorators. 
```
WARNING: ember-decorators (used in ember-bulma): You have not installed @ember-decorators/babel-transforms. It has been extracted to a separate addon. See instructions for installation: https://github.com/ember-decorators/babel-transforms#readme
```